### PR TITLE
simplify saved recording filename

### DIFF
--- a/src/components/avatar-recorder.js
+++ b/src/components/avatar-recorder.js
@@ -218,7 +218,7 @@ AFRAME.registerComponent('avatar-recorder', {
     var type = this.data.binaryFormat ? 'application/octet-binary' : 'application/json';
     var blob = new Blob([jsonData], {type: type});
     var url = URL.createObjectURL(blob);
-    var fileName = 'player-recording-' + document.title + '-' + Date.now() + '.json';
+    var fileName = 'recording-' + document.title.toLowerCase().replace(/ /g, '-') + '.json';
     var aEl = document.createElement('a');
     aEl.href = url;
     aEl.setAttribute('download', fileName);


### PR DESCRIPTION
`player-recording-MyApp-1491261421137.json` -> `recording-myapp.json`

The OS will handle duplicate file names. On OS X, it'll create `recording-myapp (1).json`, which is easier to differentiate and get a handle on that the large timestamps.