### PR TITLE
allow disabling of avatar-replayer from query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The `avatar-recorder` will automatically set the `avatar-replayer` component.
 Though we can specify the `avatar-replayer` explicitly if we want to configure
 it or if we don't need recording (i.e., production).
 
+`avatar-replayer` can be manually disabled from the URL query parameter
+`avatar-replayer-disabled` (e.g.,
+`http://localhost:8000/?avatar-replayer-disabled`).
+
 ##### From localStorage
 
 By default, the `avatar-recorder` will save the recording into `localStorage`

--- a/src/components/avatar-replayer.js
+++ b/src/components/avatar-replayer.js
@@ -96,6 +96,11 @@ AFRAME.registerComponent('avatar-replayer', {
     var queryParamSrc;
     var src;
 
+    // Allow override to display replayer from query param.
+    if (new URLSearchParams(window.location.search).get('avatar-replayer-disabled') !== null) {
+      return;
+    }
+
     // From localStorage.
     localStorageData = JSON.parse(localStorage.getItem('avatar-recording'));
     if (localStorageData) {


### PR DESCRIPTION
I often go to take a recording on another machine but I forgot to remove the `avatar-replayer` from my development HTML.

Or I am using replaying on one machine, but want to test without recording on another without having to change my HTML.

Or sometimes I want to share my project without replaying even though I have `avatar-replayer` set in the HTML. 

Or cases where people publish with the `avatar-replayer` set and need a way to have a URL with it disabled.