### PR TITLE
Updates for A-Frame v0.8.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/dmarcos/aframe-motion-capture-components#readme",
   "devDependencies": {
-    "aframe": "0.6.1",
+    "aframe": "^0.8.2",
     "chai": "^3.4.1",
     "chai-shallow-deep-equal": "^1.3.0",
     "cross-env": "^3.1.3",

--- a/src/components/motion-capture-replayer.js
+++ b/src/components/motion-capture-replayer.js
@@ -216,4 +216,5 @@ AFRAME.registerComponent('motion-capture-replayer', {
 function applyPose (el, pose) {
   el.setAttribute('position', pose.position);
   el.setAttribute('rotation', pose.rotation);
+  el.object3D.updateMatrix()
 };

--- a/src/components/motion-capture-replayer.js
+++ b/src/components/motion-capture-replayer.js
@@ -102,7 +102,7 @@ AFRAME.registerComponent('motion-capture-replayer', {
     if (data.gamepad) {
       this.gamepadData = data.gamepad;
       el.sceneEl.systems['motion-capture-replayer'].gamepads.push(data.gamepad);
-      el.emit('gamepadconnected');
+      el.sceneEl.systems['motion-capture-replayer'].updateControllerList();
     }
 
     el.emit('replayingstarted');

--- a/src/systems/motion-capture-replayer.js
+++ b/src/systems/motion-capture-replayer.js
@@ -12,9 +12,9 @@ AFRAME.registerSystem('motion-capture-replayer', {
     this.gamepads = [];
 
     // Wrap `updateControllerList`.
-
     this.updateControllerListOriginal = trackedControlsSystem.updateControllerList.bind(
       trackedControlsSystem);
+    this.throttledUpdateControllerListOriginal = trackedControlsSystem.throttledUpdateControllerList
     trackedControlsSystem.throttledUpdateControllerList = this.updateControllerList.bind(this);
 
     // Wrap `tracked-controls` tick.
@@ -29,7 +29,7 @@ AFRAME.registerSystem('motion-capture-replayer', {
     var trackedControlsSystem = this.sceneEl.systems['tracked-controls'];
     trackedControlsComponent.tick = trackedControlsComponent.trackedControlsTick;
     delete trackedControlsComponent.trackedControlsTick;
-    trackedControlsSystem.throttledUpdateControllerList = this.updateControllerListOriginal;
+    trackedControlsSystem.throttledUpdateControllerList = this.throttledUpdateControllerListOriginal;
   },
 
   trackedControlsTickWrapper: function (time, delta) {

--- a/src/systems/motion-capture-replayer.js
+++ b/src/systems/motion-capture-replayer.js
@@ -12,9 +12,11 @@ AFRAME.registerSystem('motion-capture-replayer', {
     this.gamepads = [];
 
     // Wrap `updateControllerList`.
+
     this.updateControllerListOriginal = trackedControlsSystem.updateControllerList.bind(
       trackedControlsSystem);
-    trackedControlsSystem.updateControllerList = this.updateControllerList.bind(this);
+    trackedControlsSystem.throttledUpdateControllerList = AFRAME.utils
+      .throttle(this.updateControllerList, 500, this);
 
     // Wrap `tracked-controls` tick.
     trackedControlsComponent = AFRAME.components['tracked-controls'].Component.prototype;
@@ -28,7 +30,7 @@ AFRAME.registerSystem('motion-capture-replayer', {
     var trackedControlsSystem = this.sceneEl.systems['tracked-controls'];
     trackedControlsComponent.tick = trackedControlsComponent.trackedControlsTick;
     delete trackedControlsComponent.trackedControlsTick;
-    trackedControlsSystem.updateControllerList = this.updateControllerListOriginal;
+    trackedControlsSystem.throttledUpdateControllerList = this.updateControllerListOriginal;
   },
 
   trackedControlsTickWrapper: function (time, delta) {
@@ -43,8 +45,9 @@ AFRAME.registerSystem('motion-capture-replayer', {
     var i;
     var sceneEl = this.sceneEl;
     var trackedControlsSystem = sceneEl.systems['tracked-controls'];
+    var realGamepads = navigator.getGamepads && navigator.getGamepads();
 
-    this.updateControllerListOriginal();
+    this.updateControllerListOriginal(realGamepads);
 
     this.gamepads.forEach(function (gamepad) {
       if (trackedControlsSystem.controllers[gamepad.index]) { return; }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -399,23 +399,21 @@ suite('motion-capture-replayer system', function () {
     el.setAttribute('motion-capture-replayer', 'loop: false');
   });
 
-  test('injects tracked-controls', function () {
-    var controllersUpdatedSpy = new sinon.spy()
+  test('injects tracked-controls', function (done) {
     assert.equal(el.sceneEl.systems['tracked-controls'].controllers.length, 0);
+
+    el.sceneEl.addEventListener('controllersupdated', () => {
+      assert.equal(el.sceneEl.systems['motion-capture-replayer'].gamepads.length, 1);
+      assert.equal(el.sceneEl.systems['tracked-controls'].controllers.length, 1);
+      assert.equal(el.sceneEl.systems['tracked-controls'].controllers[0].id,
+                   'OpenVR Controller');
+      done();
+    });
+
     el.components['motion-capture-replayer'].startReplaying({
       gamepad: {id: 'OpenVR Controller', index: 1, hand: 'left'},
       poses: [{timestamp: 100, position: '1 1 1', rotation: '90 90 90'}],
       events: []
     });
-
-    assert.equal(el.sceneEl.systems['motion-capture-replayer'].gamepads.length, 1);
-
-    el.sceneEl.addEventListener('controllersupdated', controllersUpdatedSpy);
-
-    el.sceneEl.systems['motion-capture-replayer'].updateControllerList();
-    assert.equal(el.sceneEl.systems['tracked-controls'].controllers.length, 2);
-    assert.equal(el.sceneEl.systems['tracked-controls'].controllers[1].id,
-                 'OpenVR Controller');
-    assert.isTrue(controllersUpdatedSpy.called)
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -321,6 +321,8 @@ suite('motion-capture-replayer', function () {
   });
 
   test('plays poses', function () {
+    var rotTemp
+
     assert.shallowDeepEqual(el.getAttribute('position'), {x: 0, y: 0, z: 0});
     assert.shallowDeepEqual(el.getAttribute('rotation'), {x: 0, y: 0, z: 0});
 
@@ -336,11 +338,19 @@ suite('motion-capture-replayer', function () {
 
     component.tick(200, 50);
     assert.shallowDeepEqual(el.getAttribute('position'), {x: 2, y: 2, z: 2});
-    assert.shallowDeepEqual(el.getAttribute('rotation'), {x: 60, y: 60, z: 60});
+    rotTemp = el.getAttribute('rotation');
+    rotTemp.x = Math.round(rotTemp.x);
+    rotTemp.y = Math.round(rotTemp.y);
+    rotTemp.z = Math.round(rotTemp.z);
+    assert.shallowDeepEqual(rotTemp, {x: 60, y: 60, z: 60});
 
     component.tick(300, 100);
     assert.shallowDeepEqual(el.getAttribute('position'), {x: 3, y: 3, z: 3});
-    assert.shallowDeepEqual(el.getAttribute('rotation'), {x: 30, y: 30, z: 30});
+    rotTemp = el.getAttribute('rotation');
+    rotTemp.x = Math.round(rotTemp.x);
+    rotTemp.y = Math.round(rotTemp.y);
+    rotTemp.z = Math.round(rotTemp.z);
+    assert.shallowDeepEqual(rotTemp, {x: 30, y: 30, z: 30});
   });
 
   test('plays events', function (done) {
@@ -389,7 +399,9 @@ suite('motion-capture-replayer system', function () {
     el.setAttribute('motion-capture-replayer', 'loop: false');
   });
 
-  test('injects tracked-controls', function (done) {
+  test('injects tracked-controls', function () {
+    var controllersUpdatedSpy = new sinon.spy()
+    assert.equal(el.sceneEl.systems['tracked-controls'].controllers.length, 0);
     el.components['motion-capture-replayer'].startReplaying({
       gamepad: {id: 'OpenVR Controller', index: 1, hand: 'left'},
       poses: [{timestamp: 100, position: '1 1 1', rotation: '90 90 90'}],
@@ -397,15 +409,13 @@ suite('motion-capture-replayer system', function () {
     });
 
     assert.equal(el.sceneEl.systems['motion-capture-replayer'].gamepads.length, 1);
-    assert.equal(el.sceneEl.systems['tracked-controls'].controllers.length, 0);
 
-    el.sceneEl.addEventListener('controllersupdated', () => {
-      assert.equal(el.sceneEl.systems['tracked-controls'].controllers.length, 2);
-      assert.equal(el.sceneEl.systems['tracked-controls'].controllers[1].id,
-                   'OpenVR Controller');
-      done();
-    });
+    el.sceneEl.addEventListener('controllersupdated', controllersUpdatedSpy);
 
     el.sceneEl.systems['motion-capture-replayer'].updateControllerList();
+    assert.equal(el.sceneEl.systems['tracked-controls'].controllers.length, 2);
+    assert.equal(el.sceneEl.systems['tracked-controls'].controllers[1].id,
+                 'OpenVR Controller');
+    assert.isTrue(controllersUpdatedSpy.called)
   });
 });


### PR DESCRIPTION
Updates required for compatibility with changes to tracked controls system gamepad connection flow in A-Frame v0.8.0. Fixes #39

I believe it is still impossible to capture new recordings, but this patch allows me to successfully run my machinima tests for super-hands with current A-Frame versions. 

1. Bypass deprecated 'gamepadconnected' event
2. Update tracked-controls system updateControllerList wrapping to overwrite the new `throttledUpdateControllerList` property
3. Provide current real gamepad list to original updateControllerList as it no longer queries this on its own and doesn't clear out the controller list otherwise, sometimes preventing a recorded controller from activating when its index had been filled with a "finger" stub before it activated